### PR TITLE
Added timeouts for LispWorks.

### DIFF
--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -67,11 +67,5 @@ set."
   #+:cmu
   (setf (lisp::fd-stream-timeout (usocket:socket-stream usocket))
         (coerce read-timeout 'integer))
-  #+lispworks
-  (when read-timeout
-    (setf (stream:stream-read-timeout (usocket:socket-stream usocket)) read-timeout))
-  #+lispworks
-  (when write-timeout
-    (setf (stream:stream-write-timeout (usocket:socket-stream usocket)) write-timeout))
-  #-(or :clisp :ecl :openmcl :sbcl :cmu :lispworks)
+  #-(or :clisp :ecl :openmcl :sbcl :cmu)
   (not-implemented 'set-timeouts))

--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -67,5 +67,11 @@ set."
   #+:cmu
   (setf (lisp::fd-stream-timeout (usocket:socket-stream usocket))
         (coerce read-timeout 'integer))
-  #-(or :clisp :ecl :openmcl :sbcl :cmu)
+  #+lispworks
+  (when read-timeout
+    (usocket::set-socket-receive-timeout (usocket:socket usocket) read-timeout))
+  #+lispworks
+  (when write-timeout
+    (usocket::set-socket-send-timeout  (usocket:socket usocket) write-timeout))
+  #-(or :clisp :ecl :openmcl :sbcl :cmu :lispworks)
   (not-implemented 'set-timeouts))

--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -67,5 +67,11 @@ set."
   #+:cmu
   (setf (lisp::fd-stream-timeout (usocket:socket-stream usocket))
         (coerce read-timeout 'integer))
-  #-(or :clisp :ecl :openmcl :sbcl :cmu)
+  #+lispworks
+  (when read-timeout
+    (setf (stream:stream-read-timeout (usocket:socket-stream usocket)) read-timeout))
+  #+lispworks
+  (when write-timeout
+    (setf (stream:stream-write-timeout (usocket:socket-stream usocket)) write-timeout))
+  #-(or :clisp :ecl :openmcl :sbcl :cmu :lispworks)
   (not-implemented 'set-timeouts))


### PR DESCRIPTION
I have added support for setting read and write timeouts on LispWorks. Testing has mainly consisted of successfully calling `(toot:start-server :port 8080 :handler (lambda (r) 'not-handled))` as per the docs.

I gather best practice is for the pull request to come from its own branch, but my Git-fu is pretty weak...

It's interesting that no other LispWorks user has found & tackled this issue in the last four years... :)

Cheers,

John :^P
