### PR TITLE
added support for clasp

### DIFF
--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -54,6 +54,12 @@ set."
   #+:ecl
   (when read-timeout
     (setf (sb-bsd-sockets:sockopt-receive-timeout (usocket:socket usocket)) read-timeout))
+  #+:clasp
+  (when write-timeout
+    (setf (sb-bsd-sockets:sockopt-send-timeout (usocket:socket usocket)) write-timeout))
+  #+:clasp
+  (when read-timeout
+    (setf (sb-bsd-sockets:sockopt-receive-timeout (usocket:socket usocket)) read-timeout))
   #+:openmcl
   (when read-timeout
     (setf (ccl:stream-input-timeout (usocket:socket usocket)) read-timeout))

--- a/set-timeouts.lisp
+++ b/set-timeouts.lisp
@@ -73,5 +73,5 @@ set."
   #+:cmu
   (setf (lisp::fd-stream-timeout (usocket:socket-stream usocket))
         (coerce read-timeout 'integer))
-  #-(or :clisp :ecl :openmcl :sbcl :cmu)
+  #-(or :clisp :ecl :clasp :openmcl :sbcl :cmu)
   (not-implemented 'set-timeouts))


### PR DESCRIPTION
Hi there - we implemented a new Common Lisp implementation and wanted to use toot.

It's very much like ECL so I duplicated ECL's customization for set-timeout.

